### PR TITLE
Update license to legal name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 HackUPC Team
+Copyright (c) 2019 Hackers at UPC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Change name on license from HackUPC to Hackers at UPC (legal name from our entity).